### PR TITLE
Standardize searching for movies with optional release date

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This is a skill built for Amazon's Alexa service that tells you about your Couch
 allows you to ask Alexa the following:
 
 > Alexa, ask Couch Potato to add The Godfather
-
+> Alexa, ask Couch Potato to add The Godfather released in 1974
 > Alexa, ask Couch Potato if The Dark Knight is on the list
+> Alexa, ask Couch Potato if Batman 1989 is on the list
 
 If you're just getting started developing skills for Alexa, I'd recommend reading [Getting Started
 with the Alexa Skills

--- a/interaction_model/sample_utterances.txt
+++ b/interaction_model/sample_utterances.txt
@@ -19,6 +19,13 @@ AddMovie add {The Avengers|movieName} from {releaseDate}
 AddMovie add {The Dark Knight|movieName} from {releaseDate}
 AddMovie add {Live or Let Die|movieName} from {releaseDate}
 
+AddMovie add {The Godfather|movieName} year {releaseDate}
+AddMovie add {Star Wars|movieName} year {releaseDate}
+AddMovie add {Star Wars Episode Four A New Hope|movieName} year {releaseDate}
+AddMovie add {The Avengers|movieName} year {releaseDate}
+AddMovie add {The Dark Knight|movieName} year {releaseDate}
+AddMovie add {Live or Let Die|movieName} year {releaseDate}
+
 AddMovie add {The Godfather|movieName} released in {releaseDate}
 AddMovie add {Star Wars|movieName} released in {releaseDate}
 AddMovie add {Star Wars Episode Four A New Hope|movieName} released in {releaseDate}
@@ -67,6 +74,13 @@ FindMovie if {Star Wars Episode Four A New Hope|movieName} from {releaseDate} is
 FindMovie if {The Avengers|movieName} from {releaseDate} is on the list
 FindMovie if {The Dark Knight|movieName} from {releaseDate} is on the list
 FindMovie if {Live or Let Die|movieName} from {releaseDate} is on the list
+
+FindMovie if {The Godfather|movieName} year {releaseDate} is on the list
+FindMovie if {Star Wars|movieName} year {releaseDate} is on the list
+FindMovie if {Star Wars Episode Four A New Hope|movieName} year {releaseDate} is on the list
+FindMovie if {The Avengers|movieName} year {releaseDate} is on the list
+FindMovie if {The Dark Knight|movieName} year {releaseDate} is on the list
+FindMovie if {Live or Let Die|movieName} year {releaseDate} is on the list
 
 FindMovie is {The Godfather|movieName} released in {releaseDate} already
 FindMovie is {Star Wars|movieName} released in {releaseDate} already

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-couchpotato",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A skill to ask Alexa about your Couch Potato queue.",
   "main": "src/index.js",
   "scripts": {

--- a/src/lib/handlers.js
+++ b/src/lib/handlers.js
@@ -63,7 +63,7 @@ export function handleAddMovieIntent(req, resp) {
 
   // Grab more results since we'll end up filtering by date
   cp.movie.search(movieName, NUM_RESULTS * 2).then(function (movies) {
-    movies = formatSearchResults(movies, releaseDate ? filterFn : undefined);
+    movies = formatSearchResults(movies);
     sendSearchResponse(movies, movieName, resp);
   });
 

--- a/src/lib/handlers.js
+++ b/src/lib/handlers.js
@@ -4,9 +4,9 @@ import CouchPotato from 'node-couchpotato';
 
 import {
   buildPrompt,
+  buildMovieQuery,
   sendSearchResponse,
-  formatSearchResults,
-  parseDate
+  formatSearchResults
 } from './utils.js';
 
 import {
@@ -32,16 +32,19 @@ export default function handleLaunchIntent(req, resp) {
 }
 
 export function handleFindMovieIntent(req, resp) {
-  const movieName = req.slot('movieName');
+  const query = buildMovieQuery(req);
 
-  cp.movie.list({search: movieName, limit_offset: NUM_RESULTS}).then(function (searchResp) {
+  cp.movie.list({
+    search: query,
+    limit_offset: NUM_RESULTS
+  }).then(function (searchResp) {
     const movies = searchResp.movies;
 
     if (!movies || !movies.length) {
-      resp.say(`Couldn't find ${movieName} queued for download. `);
+      resp.say(`Couldn't find ${query} queued for download. `);
 
-      cp.movie.search(movieName).then(function (searchResults) {
-        sendSearchResponse(searchResults, resp);
+      cp.movie.search(query).then(function (searchResults) {
+        sendSearchResponse(searchResults, null, resp);
       });
     }
     else {
@@ -57,12 +60,7 @@ export function handleFindMovieIntent(req, resp) {
 }
 
 export function handleAddMovieIntent(req, resp) {
-  const movieName = req.slot('movieName');
-  const releaseDate = parseDate(req.slot('releaseDate'));
-  const filterFn = (movie) => movie.year === releaseDate.year;
-
-  // Grab more results since we'll end up filtering by date
-  cp.movie.search(movieName, NUM_RESULTS * 2).then(function (movies) {
+  cp.movie.search(buildMovieQuery(req), NUM_RESULTS).then(function (movies) {
     movies = formatSearchResults(movies);
     sendSearchResponse(movies, movieName, resp);
   });

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -29,7 +29,7 @@ export function sendSearchResponse(movies, movieName, resp) {
     .send();
 }
 
-export function formatSearchResults(movies, filterFn = () => { return true }) {
+export function formatSearchResults(movies) {
   if (movies) {
     return movies.map((movie) => {
       return {
@@ -39,7 +39,7 @@ export function formatSearchResults(movies, filterFn = () => { return true }) {
         titles: movie.titles,
         imdb: movie.imdb
       }
-    }).filter(filterFn);
+    });
   }
 
   return [];

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -17,6 +17,13 @@ export function buildPrompt(movies) {
   return promptData;
 }
 
+export function buildMovieQuery(req) {
+  const movieName = req.slot('movieName');
+  const releaseDate = parseDate(req.slot('releaseDate'));
+
+  return releaseDate ? `${movieName} ${releaseDate.year}` : movieName;
+}
+
 export function sendSearchResponse(movies, movieName, resp) {
   if (!movies || !movies.length > 0) {
     return resp.say('No movie found for ' + movieName).send();


### PR DESCRIPTION
This makes it so that both the add and find intents can both optionally take a release date to do searches on. Also, @sharepointalex pointed out that putting the year directly in the query seems to work, which I just confirmed it does. I could've sworn I tried that last night and I got a different result, but I guess I was doing something else wrong.

This also adds another utterance for searching by year which allows you to say "year".

@Hackworth @sharepointalex 
